### PR TITLE
Add full path to resolve error

### DIFF
--- a/srv/ihuman_simulations.sh
+++ b/srv/ihuman_simulations.sh
@@ -13,4 +13,4 @@
 #SBATCH --partition=standard
 
 module load matlab/R2020a
-matlab -nodisplay -nodesktop -r "./ihuman_scCOBRA ; exit"
+matlab -nodisplay -nodesktop -r "/home/scampit/Turbo/scampit/Software/emt/src/ihuman_scCOBRA.m; exit"

--- a/srv/recon1_simulations.sh
+++ b/srv/recon1_simulations.sh
@@ -13,4 +13,4 @@
 #SBATCH --partition=standard
 
 module load matlab/R2020a
-matlab -nodisplay -nodesktop -r "./recon1_scCOBRA ; exit"
+matlab -nodisplay -nodesktop -r "/home/scampit/Turbo/scampit/Software/emt/src/recon1_scCOBRA ; exit"


### PR DESCRIPTION
Initial error resulted in
```
./ihuman_scCOBRA ; exit
 |
Error: Invalid use of operator.
```